### PR TITLE
Add compatability for Laravel 8

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^8.0|^7.4",
-        "laravel/framework": "^8.0",
+        "php": "^7.4.0 | ^8.0.0",
+        "laravel/framework": "^7.8.0 | ^8.0.0",
         "ext-json": "*",
         "predis/predis": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
         }
     ],
     "require": {
-        "php": "^7.4",
-        "laravel/framework": "^7.0",
+        "php": "^8.0|^7.4",
+        "laravel/framework": "^8.0",
         "ext-json": "*",
         "predis/predis": "^1.1"
     },

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     ],
     "require": {
         "php": "^7.4.0 | ^8.0.0",
-        "laravel/framework": "^7.8.0 | ^8.0.0",
+        "laravel/framework": "^7.0.0 | ^8.0.0",
         "ext-json": "*",
         "predis/predis": "^1.1"
     },


### PR DESCRIPTION
This PR updates this package's composer.json to accept Laravel 8 and PHP 8.
This has been tested locally using the `php artisan test` Test-Suite